### PR TITLE
Add option to use PTT as momentary switch

### DIFF
--- a/SuperMacro/Actions/KeystrokeBase.cs
+++ b/SuperMacro/Actions/KeystrokeBase.cs
@@ -28,6 +28,10 @@ namespace SuperMacro.Actions
 
             [JsonProperty(PropertyName = "delay")]
             public string Delay { get; set; }
+
+            [JsonProperty(PropertyName = "isMomentary")]
+            public bool IsMomentary { get; set; }
+            
         }
 
         #region Private Members
@@ -226,7 +230,9 @@ namespace SuperMacro.Actions
 
         private void HandleAutoStop()
         {
-            if (autoStopNum > 0)
+            if (settings.IsMomentary)
+                keyPressed = false;
+            else if (autoStopNum > 0)
             {
                 counter--;
                 if (counter <= 0)
@@ -238,7 +244,7 @@ namespace SuperMacro.Actions
 
         private WriterSettings CreateWriterSettings()
         {
-            return new WriterSettings(false, false, false, false, false, delay, autoStopNum);
+            return new WriterSettings(false, false, false, false, false, false, delay, autoStopNum);
         }
 
 

--- a/SuperMacro/Actions/StickySuperMacroAction.cs
+++ b/SuperMacro/Actions/StickySuperMacroAction.cs
@@ -140,7 +140,7 @@ namespace SuperMacro.Actions
 
         private WriterSettings CreateWriterSettings()
         {
-            return new WriterSettings(settings.IgnoreNewline, settings.EnterMode, Settings.RunUntilEnd, settings.KeydownDelay, settings.ForcedMacro, settings.Delay, autoStopNum);
+            return new WriterSettings(settings.IgnoreNewline, settings.EnterMode, Settings.RunUntilEnd, settings.KeydownDelay, settings.ForcedMacro, false, settings.Delay, autoStopNum);
         }
 
         #endregion

--- a/SuperMacro/Actions/SuperMacroAction.cs
+++ b/SuperMacro/Actions/SuperMacroAction.cs
@@ -194,7 +194,7 @@ namespace SuperMacro.Actions
 
         private WriterSettings CreateWriterSettings()
         {
-            return new WriterSettings(settings.IgnoreNewline, settings.EnterMode, false, settings.KeydownDelay, settings.ForcedMacro, settings.Delay, 0);
+            return new WriterSettings(settings.IgnoreNewline, settings.EnterMode, false, settings.KeydownDelay, settings.ForcedMacro, false, settings.Delay, 0);
         }
 
         #endregion

--- a/SuperMacro/Actions/ToggleSuperMacroAction.cs
+++ b/SuperMacro/Actions/ToggleSuperMacroAction.cs
@@ -266,7 +266,7 @@ namespace SuperMacro.Actions
 
         private WriterSettings CreateWriterSettings()
         {
-            return new WriterSettings(settings.IgnoreNewline, settings.EnterMode, false, settings.KeydownDelay, settings.ForcedMacro, settings.Delay, 0);
+            return new WriterSettings(settings.IgnoreNewline, settings.EnterMode, false, settings.KeydownDelay, settings.ForcedMacro, false, settings.Delay, 0);
         }
 
         #endregion

--- a/SuperMacro/Backend/WriterSettings.cs
+++ b/SuperMacro/Backend/WriterSettings.cs
@@ -22,8 +22,11 @@ namespace SuperMacro.Backend
 
         public int AutoStopNum { get; private set; }
 
-        public WriterSettings(bool ignoreNewLine, bool enterMode, bool runUntilEnd, bool keydownDelay, bool forcedMacro, int delay, int autoStopNum)
+        public bool IsMomentary { get; private set; }
+
+        public WriterSettings(bool ignoreNewLine, bool enterMode, bool runUntilEnd, bool keydownDelay, bool forcedMacro, bool isMomentary, int delay, int autoStopNum)
         {
+            IsMomentary = isMomentary;
             IgnoreNewline = ignoreNewLine;
             EnterMode = enterMode;
             RunUntilEnd = runUntilEnd;

--- a/SuperMacro/PropertyInspector/SuperMacro/KeystrokePTT.html
+++ b/SuperMacro/PropertyInspector/SuperMacro/KeystrokePTT.html
@@ -59,6 +59,12 @@
         <div class="sdpi-item">
             <span class="titleAlignedSmall">(Use left/right keys for added precision)</span>
         </div>
+        <div type="checkbox" class="sdpi-item">
+            <div class="sdpi-item-value">
+                <input id="isMomentary" type="checkbox" value="" class="sdProperty sdCheckbox" oninput="setSettings()">
+                <label for="isMomentary" class="sdpi-item-label"><span></span>Run once (momentary switch)</label>
+            </div>
+        </div>
         <div class="sdpi-info-label hidden" style="top: -1000;" value="">Tooltip</div>
     </div>
 </body>


### PR DESCRIPTION
Added boolean to allow PTT to function as a momentary switch; same as setting 'stop after' to 1, if that were a feature of PTT.